### PR TITLE
Fix test issues

### DIFF
--- a/src/main/java/seedu/sudohr/model/ModelManager.java
+++ b/src/main/java/seedu/sudohr/model/ModelManager.java
@@ -41,7 +41,6 @@ public class ModelManager implements Model {
         this.sudoHr = new SudoHr(sudoHr);
         this.userPrefs = new UserPrefs(userPrefs);
 
-
         filteredEmployees = new FilteredList<>(this.sudoHr.getEmployeeList());
         filteredDepartments = new FilteredList<>(this.sudoHr.getDepartmentList());
         filteredLeaves = new FilteredList<>(this.sudoHr.getLeavesList());
@@ -352,7 +351,9 @@ public class ModelManager implements Model {
         ModelManager other = (ModelManager) obj;
         return sudoHr.equals(other.sudoHr)
                 && userPrefs.equals(other.userPrefs)
-                && filteredEmployees.equals(other.filteredEmployees);
+                && filteredEmployees.equals(other.filteredEmployees)
+                && filteredDepartments.equals(other.filteredDepartments)
+                && filteredLeaves.equals(other.filteredLeaves);
     }
 
 }

--- a/src/test/java/seedu/sudohr/logic/commands/department/EditDepartmentCommandTest.java
+++ b/src/test/java/seedu/sudohr/logic/commands/department/EditDepartmentCommandTest.java
@@ -43,7 +43,7 @@ public class EditDepartmentCommandTest {
         String expectedMessage = String.format(EditDepartmentCommand.MESSAGE_EDIT_DEPARTMENT_SUCCESS, editedDepartment);
 
         Model expectedModel = new ModelManager(new SudoHr(model.getSudoHr()), new UserPrefs());
-        expectedModel.setDepartment(model.getDepartment(DEPARTMENT_NAME_FIRST), editedDepartment);
+        expectedModel.removeDepartment(new Department(DEPARTMENT_NAME_SECOND));
 
         model.removeDepartment(new Department(DEPARTMENT_NAME_FIRST));
 

--- a/src/test/java/seedu/sudohr/logic/commands/department/EditDepartmentCommandTest.java
+++ b/src/test/java/seedu/sudohr/logic/commands/department/EditDepartmentCommandTest.java
@@ -33,7 +33,6 @@ public class EditDepartmentCommandTest {
 
     private Model model = new ModelManager(getTypicalSudoHr(), new UserPrefs());
 
-    // BUGGED
     @Test
     public void execute_allFieldsSpecifiedUnfilteredList_success() {
         Department editedDepartment = new DepartmentBuilder().build();
@@ -48,8 +47,7 @@ public class EditDepartmentCommandTest {
 
         model.removeDepartment(new Department(DEPARTMENT_NAME_FIRST));
 
-        // assertCommandSuccess(editDepartmentCommand, model, expectedMessage, expectedModel);
-        return;
+        assertCommandSuccess(editDepartmentCommand, model, expectedMessage, expectedModel);
     }
 
     @Test

--- a/src/test/java/seedu/sudohr/logic/commands/department/ListEmployeeDepartmentCommandTest.java
+++ b/src/test/java/seedu/sudohr/logic/commands/department/ListEmployeeDepartmentCommandTest.java
@@ -27,7 +27,15 @@ public class ListEmployeeDepartmentCommandTest {
     }
 
     @Test
-    public void execute_listIsFiltered_showsSameList() {
+    public void execute_listIsFiltered_shows2Departments() {
+        expectedModel.updateFilteredDepartmentList(new DepartmentContainsEmployeePredicate(new Id("102")));
+        assertCommandSuccess(new ListEmployeeDepartmentCommand(new DepartmentContainsEmployeePredicate(new Id("102"))),
+                model, String.format(Messages.MESSAGE_DEPARTMENTS_LISTED_OVERVIEW, 2), expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFiltered_shows1Departmentt() {
+        expectedModel.updateFilteredDepartmentList(new DepartmentContainsEmployeePredicate(new Id("101")));
         assertCommandSuccess(new ListEmployeeDepartmentCommand(new DepartmentContainsEmployeePredicate(new Id("101"))),
                 model, String.format(Messages.MESSAGE_DEPARTMENTS_LISTED_OVERVIEW, 1), expectedModel);
     }

--- a/src/test/java/seedu/sudohr/logic/commands/department/ListEmployeeDepartmentCommandTest.java
+++ b/src/test/java/seedu/sudohr/logic/commands/department/ListEmployeeDepartmentCommandTest.java
@@ -26,7 +26,6 @@ public class ListEmployeeDepartmentCommandTest {
         expectedModel = new ModelManager(model.getSudoHr(), new UserPrefs());
     }
 
-    // BUGGED
     @Test
     public void execute_listIsFiltered_shows2Departments() {
         expectedModel.updateFilteredDepartmentList(new DepartmentContainsEmployeePredicate(new Id("102")));

--- a/src/test/java/seedu/sudohr/logic/commands/department/ListEmployeesInDepartmentCommandTest.java
+++ b/src/test/java/seedu/sudohr/logic/commands/department/ListEmployeesInDepartmentCommandTest.java
@@ -49,6 +49,7 @@ public class ListEmployeesInDepartmentCommandTest {
         DepartmentName departmentName = HUMAN_RESOURCES_DEPARTMENT_NAME;
         String expectedMessage = String.format(ListEmployeesInDepartmentCommand.MESSAGE_SUCCESS, departmentName);
         expectedModel.updateFilteredEmployeeList(e -> department.hasEmployee(e));
+        expectedModel.updateFilteredDepartmentList(unused -> false);
         ListEmployeesInDepartmentCommand command = new ListEmployeesInDepartmentCommand(departmentName);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/sudohr/logic/commands/department/ListEmployeesInDepartmentCommandTest.java
+++ b/src/test/java/seedu/sudohr/logic/commands/department/ListEmployeesInDepartmentCommandTest.java
@@ -42,7 +42,6 @@ public class ListEmployeesInDepartmentCommandTest {
 
     }
 
-    // BUGGED
     @Test
     public void execute_filteredList_success() {
         model.updateFilteredDepartmentList(unused -> false);
@@ -52,7 +51,7 @@ public class ListEmployeesInDepartmentCommandTest {
         expectedModel.updateFilteredEmployeeList(e -> department.hasEmployee(e));
         expectedModel.updateFilteredDepartmentList(unused -> false);
         ListEmployeesInDepartmentCommand command = new ListEmployeesInDepartmentCommand(departmentName);
-        // assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
         return;
     }
 


### PR DESCRIPTION
Fixed model manager to compare filtered departments and filtered leave lists during equality check.

Fixed test cases for:

ListEmployeeDepartmentCommand
EditDepartmentCommand (added one more new test case as well)
ListEmployeesInDepartmentCommand