### PR TITLE
Branch department filter logic

### DIFF
--- a/src/main/java/seedu/sudohr/logic/commands/department/AddEmployeeToDepartmentCommand.java
+++ b/src/main/java/seedu/sudohr/logic/commands/department/AddEmployeeToDepartmentCommand.java
@@ -65,8 +65,14 @@ public class AddEmployeeToDepartmentCommand extends Command {
         }
 
         model.addEmployeeToDepartment(employee, department);
-        model.updateFilteredDepartmentList(Model.PREDICATE_SHOW_ALL_DEPARTMENTS);
-        model.updateFilteredEmployeeList(Model.PREDICATE_SHOW_ALL_EMPLOYEES);
+
+        // only show the relevant department
+        model.updateFilteredDepartmentList(d -> d.equals(department));
+
+        // show the employees within this department
+        model.updateFilteredEmployeeList(e -> department.hasEmployee(e));
+
+
         return new CommandResult(String.format(MESSAGE_ADD_EMPLOYEE_TO_DEPARTMENT_SUCCESS, employee, department));
     }
 
@@ -77,4 +83,6 @@ public class AddEmployeeToDepartmentCommand extends Command {
                 && toAdd.equals(((AddEmployeeToDepartmentCommand) other).toAdd)
                 && departmentName.equals(((AddEmployeeToDepartmentCommand) other).departmentName));
     }
+
+
 }

--- a/src/main/java/seedu/sudohr/logic/commands/department/ListDepartmentHeadcountCommand.java
+++ b/src/main/java/seedu/sudohr/logic/commands/department/ListDepartmentHeadcountCommand.java
@@ -76,7 +76,15 @@ public class ListDepartmentHeadcountCommand extends Command {
                 ? e -> true
                 : e -> !leaveOnGivenDate.hasEmployee(e);
 
+
+        // show all employees present on that day in the given department
         model.updateFilteredEmployeeList(predicateEmployeeInDepartment.and(predicateEmployeePresent));
+
+        // show the relevant department
+        model.updateFilteredDepartmentList(d -> d.equals(department));
+
+        // show the leaves on the date
+        model.updateFilteredLeaveList(l -> l.equals(leaveOnGivenDate));
 
         return new CommandResult(
                 String.format(MESSAGE_SUCCESS, model.getFilteredEmployeeList().size(), departmentName));

--- a/src/main/java/seedu/sudohr/logic/commands/department/RemoveEmployeeFromDepartmentCommand.java
+++ b/src/main/java/seedu/sudohr/logic/commands/department/RemoveEmployeeFromDepartmentCommand.java
@@ -67,8 +67,12 @@ public class RemoveEmployeeFromDepartmentCommand extends Command {
 
 
         model.removeEmployeeFromDepartment(employee, department);
-        model.updateFilteredDepartmentList(Model.PREDICATE_SHOW_ALL_DEPARTMENTS);
-        model.updateFilteredEmployeeList(Model.PREDICATE_SHOW_ALL_EMPLOYEES);
+        // only show the relevant department
+        model.updateFilteredDepartmentList(d -> d.equals(department));
+
+        // show the employees within this department
+        model.updateFilteredEmployeeList(e -> department.hasEmployee(e));
+
         return new CommandResult(String.format(MESSAGE_REMOVE_EMPLOYEE_FROM_DEPARTMENT_SUCCESS, employee, department));
     }
 

--- a/src/test/java/seedu/sudohr/logic/commands/department/ListDepartmentHeadcountCommandTest.java
+++ b/src/test/java/seedu/sudohr/logic/commands/department/ListDepartmentHeadcountCommandTest.java
@@ -26,7 +26,7 @@ import seedu.sudohr.model.Model;
 import seedu.sudohr.model.ModelManager;
 import seedu.sudohr.model.UserPrefs;
 import seedu.sudohr.model.department.DepartmentName;
-
+import seedu.sudohr.model.leave.LeaveDate;
 
 
 public class ListDepartmentHeadcountCommandTest {
@@ -90,6 +90,10 @@ public class ListDepartmentHeadcountCommandTest {
                 e -> ENGINEERING_EMPLOYEES_PRESENT_ON_DATE_TYPE_2.stream().anyMatch(e::isSameEmployee)
         );
 
+        expectedModel.updateFilteredDepartmentList(d -> d.equals(ENGINEERING));
+
+        expectedModel.updateFilteredLeaveList(l -> l.getDate().equals(new LeaveDate(LocalDate.parse(DATE_TYPE_2))));
+
         String expectedMessage2 = String.format(ListDepartmentHeadcountCommand.MESSAGE_SUCCESS,
                 ENGINEERING_EMPLOYEES_PRESENT_ON_DATE_TYPE_2.size(), engineering);
 
@@ -114,6 +118,10 @@ public class ListDepartmentHeadcountCommandTest {
                 e -> ENGINEERING_EMPLOYEES_PRESENT_ON_DATE_TYPE_3.stream().anyMatch(e::isSameEmployee)
         );
 
+        expectedModel.updateFilteredDepartmentList(d -> d.equals(ENGINEERING));
+
+        expectedModel.updateFilteredLeaveList(l -> l.getDate().equals(new LeaveDate(LocalDate.parse(DATE_TYPE_3))));
+
         assertCommandSuccess(command1, model, expectedMessage1, expectedModel);
 
 
@@ -132,6 +140,10 @@ public class ListDepartmentHeadcountCommandTest {
                 e -> SALES_EMPLOYEES_PRESENT_ON_DATE_TYPE_3.stream().anyMatch(e::isSameEmployee)
         );
 
+        expectedModel.updateFilteredDepartmentList(d -> d.equals(SALES));
+
+        expectedModel.updateFilteredLeaveList(l -> l.getDate().equals(new LeaveDate(LocalDate.parse(DATE_TYPE_3))));
+
         assertCommandSuccess(command2, model, expectedMessage2, expectedModel);
     }
 
@@ -147,6 +159,10 @@ public class ListDepartmentHeadcountCommandTest {
         expectedModel.updateFilteredEmployeeList(
                 e -> HR_EMPLOYEES_PRESENT_ON_DATE_TYPE_1.stream().anyMatch(e::isSameEmployee)
         );
+
+        expectedModel.updateFilteredDepartmentList(d -> d.equals(HUMAN_RESOURCES));
+
+        expectedModel.updateFilteredLeaveList(l -> l.getDate().equals(new LeaveDate(LocalDate.parse(DATE_TYPE_1))));
 
         String expectedMessage1 = String.format(ListDepartmentHeadcountCommand.MESSAGE_SUCCESS,
                 HR_EMPLOYEES_PRESENT_ON_DATE_TYPE_1.size(), hr);


### PR DESCRIPTION
- `aetd` and `refd`: Filter all the employees in the given department, filter the specific department, leave list remains untouched
- `ldhc`: filter the leave on the specified date, filter all the employees present on that day for the given department and filter the given department