### PR TITLE
LDHC for "today"

### DIFF
--- a/src/main/java/seedu/sudohr/logic/commands/department/ListDepartmentHeadcountCommand.java
+++ b/src/main/java/seedu/sudohr/logic/commands/department/ListDepartmentHeadcountCommand.java
@@ -30,16 +30,16 @@ public class ListDepartmentHeadcountCommand extends Command {
             + "the department on a given date. \n"
             + "Parameters: "
             + PREFIX_DEPARTMENT_NAME + "DEPARTMENT_NAME "
-            + PREFIX_DATE + "DATE\n"
+            + "[" + PREFIX_DATE + "DATE]\n"
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_DEPARTMENT_NAME + "Human Resources"
+            + PREFIX_DEPARTMENT_NAME + "Human Resources" + " "
             + PREFIX_DATE + "2023-03-04";
 
     public static final String MESSAGE_DEPARTMENT_NOT_EXIST = "The given department does not exist.";
 
     public static final String MESSAGE_INVALID_DATE_FOR_HEADCOUNT = "The given date to get headcount is invalid.";
 
-    public static final String MESSAGE_SUCCESS = "%1$d employees are present on the given date in %2$s department.";
+    public static final String MESSAGE_SUCCESS = "%1$d employees are present on %2$s in %3$s department.";
 
     private LocalDate date;
     private LocalDate currentDate;
@@ -79,7 +79,8 @@ public class ListDepartmentHeadcountCommand extends Command {
         model.updateFilteredEmployeeList(predicateEmployeeInDepartment.and(predicateEmployeePresent));
 
         return new CommandResult(
-                String.format(MESSAGE_SUCCESS, model.getFilteredEmployeeList().size(), departmentName));
+                String.format(MESSAGE_SUCCESS, model.getFilteredEmployeeList().size(),
+                        date.toString(), departmentName));
     }
 
     private boolean isValidDate(LocalDate date, LocalDate currentDate) {

--- a/src/main/java/seedu/sudohr/logic/parser/department/ListDepartmentHeadcountCommandParser.java
+++ b/src/main/java/seedu/sudohr/logic/parser/department/ListDepartmentHeadcountCommandParser.java
@@ -26,18 +26,21 @@ public class ListDepartmentHeadcountCommandParser implements Parser<ListDepartme
     public ListDepartmentHeadcountCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_DEPARTMENT_NAME, PREFIX_DATE);
 
-        if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_DATE, PREFIX_DEPARTMENT_NAME)
+        if (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_DEPARTMENT_NAME)
             || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     ListDepartmentHeadcountCommand.MESSAGE_USAGE));
         }
 
         LocalDate currentDate = LocalDate.now();
-        LocalDate date = ParserUtil.parseLocalDate(argMultimap.getValue(PREFIX_DATE).get());
+        LocalDate givenDate = argMultimap.getValue(PREFIX_DATE).isEmpty()
+                ? LocalDate.now()
+                : ParserUtil.parseLocalDate(argMultimap.getValue(PREFIX_DATE).get());
+
         DepartmentName departmentName = ParserUtil.parseDepartmentName(
                 argMultimap.getValue(PREFIX_DEPARTMENT_NAME).get()
         );
 
-        return new ListDepartmentHeadcountCommand(currentDate, date, departmentName);
+        return new ListDepartmentHeadcountCommand(currentDate, givenDate, departmentName);
     }
 }

--- a/src/test/java/seedu/sudohr/logic/commands/department/ListDepartmentHeadcountCommandTest.java
+++ b/src/test/java/seedu/sudohr/logic/commands/department/ListDepartmentHeadcountCommandTest.java
@@ -91,7 +91,7 @@ public class ListDepartmentHeadcountCommandTest {
         );
 
         String expectedMessage2 = String.format(ListDepartmentHeadcountCommand.MESSAGE_SUCCESS,
-                ENGINEERING_EMPLOYEES_PRESENT_ON_DATE_TYPE_2.size(), engineering);
+                ENGINEERING_EMPLOYEES_PRESENT_ON_DATE_TYPE_2.size(), DATE_TYPE_2, engineering);
 
         assertCommandSuccess(command2, model, expectedMessage2, expectedModel);
     }
@@ -108,7 +108,7 @@ public class ListDepartmentHeadcountCommandTest {
         );
 
         String expectedMessage1 = String.format(ListDepartmentHeadcountCommand.MESSAGE_SUCCESS,
-                ENGINEERING_EMPLOYEES_PRESENT_ON_DATE_TYPE_3.size(), engineering);
+                ENGINEERING_EMPLOYEES_PRESENT_ON_DATE_TYPE_3.size(), DATE_TYPE_3, engineering);
 
         expectedModel.updateFilteredEmployeeList(
                 e -> ENGINEERING_EMPLOYEES_PRESENT_ON_DATE_TYPE_3.stream().anyMatch(e::isSameEmployee)
@@ -124,7 +124,7 @@ public class ListDepartmentHeadcountCommandTest {
                 sales
         );
         String expectedMessage2 = String.format(ListDepartmentHeadcountCommand.MESSAGE_SUCCESS,
-                SALES_EMPLOYEES_PRESENT_ON_DATE_TYPE_3.size(), sales);
+                SALES_EMPLOYEES_PRESENT_ON_DATE_TYPE_3.size(), DATE_TYPE_3, sales);
         // refresh expected model
         expectedModel.updateFilteredEmployeeList(e -> true);
 
@@ -149,7 +149,7 @@ public class ListDepartmentHeadcountCommandTest {
         );
 
         String expectedMessage1 = String.format(ListDepartmentHeadcountCommand.MESSAGE_SUCCESS,
-                HR_EMPLOYEES_PRESENT_ON_DATE_TYPE_1.size(), hr);
+                HR_EMPLOYEES_PRESENT_ON_DATE_TYPE_1.size(), DATE_TYPE_1, hr);
 
         assertCommandSuccess(command, model, expectedMessage1, expectedModel);
 


### PR DESCRIPTION
- make `ldhc` command date argument as optional and default to current date when not given, so if you want to view the headcount for the department for today, just do not input any date argument.
- updated the messages for the command 